### PR TITLE
Add Supabase Edge Functions runtime scaffolding

### DIFF
--- a/dockerfiles/supabase-edge-functions/Dockerfile
+++ b/dockerfiles/supabase-edge-functions/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1.6
+
+# Build the Supabase CLI from source for linux/386 when possible.
+FROM --platform=$BUILDPLATFORM golang:1.24 AS supabase-builder
+ARG SUPABASE_VERSION=v2.40.7
+WORKDIR /src
+RUN git clone --depth 1 --branch ${SUPABASE_VERSION} https://github.com/supabase/cli.git .
+RUN --mount=type=cache,target=/go/pkg/mod \
+        bash -c 'set -euo pipefail; mkdir -p /out; :> /out/supabase; \
+        set +e; GOOS=linux GOARCH=386 CGO_ENABLED=0 go build -o /out/supabase ./; status=$?; \
+        set -e; echo $status > /out/build.exitcode; cp -a . /out/cli-src'
+
+# Final runtime image built for i386 to match WebVM expectations.
+FROM --platform=i386 i386/debian:bookworm
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        unzip \
+        build-essential \
+        pkg-config \
+        libssl-dev \
+        zlib1g-dev \
+        python3 \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Provide a regular user, mirroring the other runtimes.
+RUN useradd -m user && echo "user:password" | chpasswd
+
+# Bring over the compiled CLI (if available) and the upstream source tree.
+COPY --from=supabase-builder /out/supabase /opt/supabase/bin/supabase
+COPY --from=supabase-builder /out/build.exitcode /opt/supabase/bin/build.exitcode
+COPY --from=supabase-builder /out/cli-src /opt/supabase/cli-src
+
+# Runtime bootstrap files.
+COPY dockerfiles/supabase-edge-functions/edge-function.ts /opt/supabase/templates/hello/index.ts
+COPY dockerfiles/supabase-edge-functions/start-supabase-edge.sh /usr/local/bin/start-supabase-edge.sh
+
+RUN set -eux; \
+    chmod +x /usr/local/bin/start-supabase-edge.sh; \
+    mkdir -p /home/user/project/functions/hello; \
+    cp /opt/supabase/templates/hello/index.ts /home/user/project/functions/hello/index.ts; \
+    status="$(cat /opt/supabase/bin/build.exitcode)"; \
+    rm /opt/supabase/bin/build.exitcode; \
+    if [ "$status" -eq 0 ]; then \
+        install -m 0755 /opt/supabase/bin/supabase /usr/local/bin/supabase; \
+    else \
+        printf '#!/bin/sh\n' > /usr/local/bin/supabase; \
+        printf 'echo "Supabase CLI binary for linux/386 is not bundled. Review /opt/supabase/README.txt for next steps."\n' >> /usr/local/bin/supabase; \
+        chmod +x /usr/local/bin/supabase; \
+    fi; \
+    printf '%s\n' \
+      'Supabase Edge Functions rely on the Deno runtime.' \
+      'Deno releases only provide x86_64 and aarch64 builds, so serving functions in this 32-bit image is currently blocked.' \
+      'The Supabase CLI source tree is mirrored in /opt/supabase/cli-src for experimentation with cross-compilation.' \
+      > /opt/supabase/README.txt; \
+    chown -R user:user /home/user /opt/supabase
+
+USER user
+WORKDIR /home/user/project
+ENV HOME=/home/user TERM=xterm
+
+CMD ["/usr/local/bin/start-supabase-edge.sh"]

--- a/dockerfiles/supabase-edge-functions/edge-function.ts
+++ b/dockerfiles/supabase-edge-functions/edge-function.ts
@@ -1,0 +1,16 @@
+// Minimal Supabase Edge Function example for reference inside the runtime image.
+// The function simply responds with a JSON payload echoing the request URL.
+import { serve } from "https://deno.land/std@0.217.0/http/server.ts";
+
+serve((request) => {
+        const body = JSON.stringify({
+                message: "Hello from WebVM Supabase Edge Function placeholder runtime!",
+                url: request.url,
+        });
+        return new Response(body, {
+                headers: {
+                        "content-type": "application/json; charset=utf-8",
+                        "cache-control": "no-store",
+                },
+        });
+});

--- a/dockerfiles/supabase-edge-functions/start-supabase-edge.sh
+++ b/dockerfiles/supabase-edge-functions/start-supabase-edge.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+cat <<'MSG'
+Supabase Edge Functions runtime (experimental)
+==============================================
+
+This image prepares a Supabase project skeleton under /home/user/project and
+bundles research assets to help you build a full edge runtime.
+
+Key paths inside the VM:
+  • /home/user/project/functions/hello/index.ts  – sample Deno handler.
+  • /opt/supabase/README.txt                     – current limitations & next steps.
+  • /opt/supabase/cli-src                        – Supabase CLI source tree for reference.
+
+MSG
+
+if command -v supabase >/dev/null 2>&1; then
+        printf "Detected Supabase CLI: %s\n\n" "$(supabase --version || printf 'version query failed')"
+else
+        printf "Supabase CLI binary is not installed yet.\n"
+fi
+
+cat /opt/supabase/README.txt
+
+cat <<'INSTR'
+
+You can edit the function sources and run CLI commands that do not require the
+Deno runtime. Serving or deploying functions will remain blocked until upstream
+ships 32-bit Linux builds of both the Supabase CLI and Deno.
+
+Dropping into an interactive shell. Type 'exit' to terminate the process.
+INSTR
+
+exec /bin/bash

--- a/docs/ApplicationServers.md
+++ b/docs/ApplicationServers.md
@@ -1,0 +1,94 @@
+# Application Server Runtimes
+
+WebVM can boot from custom EXT2 disk images generated from Dockerfiles. This page
+documents the application-focused runtimes that we curate for the "Application
+Servers" gallery as well as the work needed to build additional images.
+
+## Static HTTP Server (reference implementation)
+
+* **Dockerfile:** [`dockerfiles/static-http/Dockerfile`](../dockerfiles/static-http/Dockerfile)
+* **Runtime goal:** serve `/home/user/www` over BusyBox `httpd` on port 8080.
+* **EXT2 build:** select `dockerfiles/static-http/Dockerfile` when triggering the
+  `Deploy` GitHub Action. The workflow exports the container root filesystem to
+  an EXT2 disk and updates the `config_github_terminal.js` file automatically.
+* **Usage:** the runtime drops into an HTTP server session immediately. You can
+  replace `default.html` or extend the Dockerfile to copy a full site before
+  building the image.
+
+This minimal runtime is a good template for "drop a single binary, run it" use
+cases. The Supabase Edge Functions runtime described below builds on the same
+workflow but requires extra tooling.
+
+## Supabase Edge Functions runtime (experimental)
+
+Supabase Edge Functions are executed by Deno; therefore a complete runtime needs
+three layers:
+
+1. the Supabase CLI to manage projects and invoke functions,
+2. the Deno runtime that actually executes the TypeScript handlers, and
+3. supporting toolchains (git, build-essential, etc.) so developers can tweak
+   the project from inside WebVM.
+
+### Release support status
+
+* Supabase currently ships Linux binaries for `amd64` and `arm64` only. The
+  v2.40.7 release assets include packages such as
+  `supabase_2.40.7_linux_amd64.deb`, `supabase_2.40.7_linux_amd64.tar.gz`, and
+  `supabase_2.40.7_linux_arm64.deb`—there is no `linux_386` variant yet.
+* The Deno project also distributes `x86_64` and `aarch64` builds exclusively.
+  The latest release publishes archives like `deno-x86_64-unknown-linux-gnu.zip`
+  and `deno-aarch64-unknown-linux-gnu.zip`, but nothing for 32-bit x86.
+
+Because WebVM images are exported as 32-bit EXT2 disks, we cannot bundle a
+working Deno binary today. The Dockerfile nevertheless lays the groundwork so we
+can drop the executables in as soon as upstream adds 32-bit support or we manage
+an in-house port.
+
+### Dockerfile overview
+
+* **Location:** [`dockerfiles/supabase-edge-functions/Dockerfile`](../dockerfiles/supabase-edge-functions/Dockerfile)
+* **Build process:** a multi-stage build compiles the Supabase CLI from source
+  for `linux/386`. The builder runs on the host architecture via BuildKit (so it
+  can use the official `golang:1.24` image) and then copies the resulting binary
+  into the 32-bit runtime layer. If the compilation fails, the image will still
+  build but a placeholder wrapper is installed instead.
+* **Runtime contents:**
+  - `/home/user/project/functions/hello/index.ts` – a sample edge function you
+    can edit immediately.
+  - `/opt/supabase/cli-src` – the Supabase CLI repository to help with manual
+    rebuilds or patching.
+  - `/opt/supabase/README.txt` – explains the remaining blockers and directs
+    maintainers to the relevant resources.
+  - `/usr/local/bin/start-supabase-edge.sh` – startup script that surfaces the
+    research summary and drops you into an interactive shell.
+
+### Building an EXT2 image
+
+1. Commit any changes you want in the Dockerfile or templates.
+2. Trigger the **Deploy** workflow with the following parameters:
+   - `DOCKERFILE_PATH = dockerfiles/supabase-edge-functions/Dockerfile`
+   - Pick an image size large enough to host your functions (512 MiB is plenty).
+   - Enable `DEPLOY_TO_GITHUB_PAGES` if you want the build hosted automatically.
+3. Download the resulting EXT2 chunks from the workflow artifact (or the GitHub
+   release if you toggled that option) and point your configuration file at the
+   generated `.ext2` image.
+
+Even though the workflow emits an EXT2 image, the startup script will currently
+warn about the missing Deno binary. You can still use the environment to edit
+functions, inspect the Supabase CLI source tree, or experiment with cross-
+compiling the CLI for `linux/386`.
+
+### Next steps once 32-bit builds are available
+
+When upstream provides compatible binaries, update the runtime as follows:
+
+1. Drop the Deno release tarball into the runtime during the Docker build and
+   add it to the `PATH`.
+2. Remove the placeholder wrapper in `/usr/local/bin/supabase` so the compiled
+   CLI is invoked directly.
+3. Extend `start-supabase-edge.sh` to call `supabase functions serve --env-file`
+   (or the desired entry point) once the runtime can actually execute edge
+   functions.
+
+Until then the runtime remains in "research" mode, but it gives us a reproducible
+build context and documentation trail for future work.


### PR DESCRIPTION
## Summary
- document the Application Servers catalog and outline the Supabase Edge Functions requirements
- add a Supabase Edge Functions Dockerfile with multi-stage build logic and placeholder assets
- bundle a startup script and sample function to explain current 32-bit limitations at runtime

## Testing
- not run (documentation and Dockerfile updates only)

------
https://chatgpt.com/codex/tasks/task_e_68cf3261e4ec83238431b06b7149ae9e