### PR TITLE
Add Node.js runtime Dockerfile

### DIFF
--- a/dockerfiles/node-runtime/Dockerfile
+++ b/dockerfiles/node-runtime/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.4
+FROM --platform=linux/386 debian:bookworm-slim AS runtime
+
+ARG NODE_VERSION=18.19.1
+ARG NODE_DISTRO=linux-x86
+
+# Install Node.js and create the runtime user.
+RUN useradd -m user \
+    && mkdir -p /home/user/app /opt/node \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl xz-utils \
+    && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_DISTRO}.tar.xz" \
+      | tar -xJ --strip-components=1 -C /opt/node \
+    && apt-get purge -y --auto-remove curl xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/opt/node/bin:${PATH}" \
+    NODE_ENV=production
+
+# Provide a starter application and launch script.
+COPY ./dockerfiles/node-runtime/server.js /home/user/app/server.js
+COPY ./dockerfiles/node-runtime/start-node.sh /usr/local/bin/start-node.sh
+RUN chown -R user:user /home/user \
+    && chmod +x /usr/local/bin/start-node.sh
+
+USER user
+WORKDIR /home/user/app
+ENV HOME=/home/user TERM=xterm
+
+CMD ["/usr/local/bin/start-node.sh"]

--- a/dockerfiles/node-runtime/server.js
+++ b/dockerfiles/node-runtime/server.js
@@ -1,0 +1,12 @@
+const http = require('node:http');
+
+const port = process.env.PORT || 8080;
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end('Hello from Node.js!\n');
+});
+
+server.listen(port, () => {
+  console.log(`Server listening on http://localhost:${port}`);
+});

--- a/dockerfiles/node-runtime/start-node.sh
+++ b/dockerfiles/node-runtime/start-node.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+cd /home/user/app
+
+if [ ! -f package.json ] && [ ! -f server.js ]; then
+  cat <<'APP' > server.js
+const http = require('node:http');
+
+const port = process.env.PORT || 8080;
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end('Hello from Node.js!\n');
+});
+
+server.listen(port, () => {
+  console.log(`Server listening on http://localhost:${port}`);
+});
+APP
+fi
+
+exec node server.js

--- a/docs/ApplicationServers.md
+++ b/docs/ApplicationServers.md
@@ -19,6 +19,21 @@ This minimal runtime is a good template for "drop a single binary, run it" use
 cases. The Supabase Edge Functions runtime described below builds on the same
 workflow but requires extra tooling.
 
+## Node.js runtime
+
+* **Dockerfile:** [`dockerfiles/node-runtime/Dockerfile`](../dockerfiles/node-runtime/Dockerfile)
+* **Runtime goal:** ship a ready-to-edit Node.js project that listens on port
+  8080 and boots straight into the sample `server.js` HTTP service.
+* **Node version:** Node.js 18.19.1 (latest 32-bit LTS release – newer major
+  versions no longer provide official `linux/386` builds).
+* **EXT2 build:** select `dockerfiles/node-runtime/Dockerfile` when triggering
+  the `Deploy` GitHub Action. A 256 MiB disk image leaves enough room for
+  `npm install` plus small projects without wasting space.
+* **Usage:** the runtime starts `/usr/local/bin/start-node.sh`, which drops you
+  into `/home/user/app`. Replace `server.js` or initialize a full project as
+  needed; the helper script only re-creates the sample server when the file is
+  missing.
+
 ## Supabase Edge Functions runtime (experimental)
 
 Supabase Edge Functions are executed by Deno; therefore a complete runtime needs


### PR DESCRIPTION
## Summary
- add a linux/386 Node.js runtime Dockerfile that installs Node 18.19.1 and configures a non-root user
- include a starter HTTP server plus bootstrap script that recreates the sample if deleted
- document the new runtime and recommend a 256 MiB EXT2 image size for deployments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf3e00a3c883238de9fc2b01f00da2